### PR TITLE
Changed showHelp default to true

### DIFF
--- a/src/app/public/modules/tiles/tile/tile.component.ts
+++ b/src/app/public/modules/tiles/tile/tile.component.ts
@@ -28,7 +28,7 @@ export class SkyTileComponent {
   public showSettings = true;
 
   @Input()
-  public showHelp = false;
+  public showHelp = true;
 
   @Output()
   public settingsClick = new EventEmitter();


### PR DESCRIPTION
Now this will match the functionality of showSettings and still show the help button when only an event subscription has been applied

Issue: #17
Docs: N/A