### PR TITLE
Fix sticky settings link

### DIFF
--- a/projects/tiles/src/modules/tiles/tile-dashboard/tile-dashboard.component.ts
+++ b/projects/tiles/src/modules/tiles/tile-dashboard/tile-dashboard.component.ts
@@ -64,9 +64,9 @@ export class SkyTileDashboardComponent implements AfterViewInit, OnDestroy {
   /**
    * Specifies a unique key for the UI Config Service to retrieve stored settings
    * from a database. The UI Config Service saves configuration settings for users
-   * to preserve the layout and collapsed state of tile dashboards. For more information
+   * to preserve the layout and collapsed state of tile dashboards. The UI Config Service relies on `id` values from the `config` property to maintain user settings. For more information
    * about the UI Config Service, see the
-   * [sticky settings documentation](https://developer.blackbaud.com/skyux/learn/get-started/advanced/sticky-settings).
+   * [sticky settings documentation](https://developer.blackbaud.com/skyux/learn/get-started/sticky-settings).
    */
   @Input()
   public settingsKey: string;


### PR DESCRIPTION
Fix link to sticky settings docs and add info to the `settingsKey` description. This PR reflects the changes done in this PR: https://blackbaud.visualstudio.com/Products/_git/skyux-spa-skyux-v5/pullrequest/221146